### PR TITLE
Update Fbl.php

### DIFF
--- a/src/Fbl.php
+++ b/src/Fbl.php
@@ -80,7 +80,11 @@ class Fbl extends Parser
                 }
 
                 // Also add the spam message body to the report
-                $report['body'] = $spamMessage->getMessageBody();
+                $report['body'] = '';
+                if ($spamMessage && $spamMessage->getMessageBody()) {                                  
+                    $report['body'] = $spamMessage->getMessageBody();
+                }
+                    
 
                 // Sanity check
                 if ($this->hasRequiredFields($report) === true) {


### PR DESCRIPTION
When not if (!empty($this->arfMail['evidence'])) on line 72, then the varialbe $spamMessage Does not gets set so the method getMessageBody cannot be called. eg When mail is nog RFC822 complaint The parse blows up because variable $spamMessage is not set. Another Idea could be to move the setting of the report body up inside the conditional checking the RFC822 complaint But this can have some consequences on the hasRequiredFields;